### PR TITLE
LLVM17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@
 
 package:
   name: compilers
-  version: 1.9.0
+  version: 1.9.1
 
 build:
    number: 0


### PR DESCRIPTION
compilers 

Rebuild to use new clang pinning in CBC to allow easily installing clang v17.0.6 compilers (and activation scripts). 

```

(test) lundby@Erics-MacBook-Pro ~ % conda install -c https://staging.continuum.io/pbp/fs/compilers-feedstock/pr2/ce35742 compilers=1.9.1
Channels:
 - https://staging.continuum.io/pbp/fs/compilers-feedstock/pr2/ce35742
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done


==> WARNING: A newer version of conda exists. <==
    current version: 25.3.1
    latest version: 25.7.0

Please update conda by running

    $ conda update -n base -c defaults conda



## Package Plan ##

  environment location: /Users/lundby/miniconda3/envs/test

  added / updated specs:
    - compilers=1.9.1


The following NEW packages will be INSTALLED:

  c-compiler         pbp/fs/compilers-feedstock/pr2/ce35742/osx-arm64::c-compiler-1.9.1-h75312c3_0 
  cctools            pkgs/main/osx-arm64::cctools-986-h0dbccd1_3 
  clang              pkgs/main/osx-arm64::clang-17.0.6-hdefe189_6 
  clang-17           pkgs/main/osx-arm64::clang-17-17.0.6-default_h000693a_6 
  clang_impl_osx-ar~ pkgs/main/osx-arm64::clang_impl_osx-arm64-17.0.6-hcb56dc5_4 
  clang_osx-arm64    pkgs/main/osx-arm64::clang_osx-arm64-17.0.6-hcb56dc5_4 
  clangxx            pkgs/main/osx-arm64::clangxx-17.0.6-default_h000693a_6 
  clangxx_impl_osx-~ pkgs/main/osx-arm64::clangxx_impl_osx-arm64-17.0.6-h39b79ac_4 
  clangxx_osx-arm64  pkgs/main/osx-arm64::clangxx_osx-arm64-17.0.6-hcb56dc5_4 
  compiler-rt        pkgs/main/osx-arm64::compiler-rt-17.0.6-h6a6761b_1 
  compiler-rt_osx-a~ pkgs/main/osx-arm64::compiler-rt_osx-arm64-17.0.6-h6a6761b_1 
  compilers          pbp/fs/compilers-feedstock/pr2/ce35742/osx-arm64::compilers-1.9.1-hca03da5_0 
  cxx-compiler       pbp/fs/compilers-feedstock/pr2/ce35742/osx-arm64::cxx-compiler-1.9.1-he55b153_0 
  fortran-compiler   pbp/fs/compilers-feedstock/pr2/ce35742/osx-arm64::fortran-compiler-1.9.1-h5c6ff0e_0 
  gfortran_impl_osx~ pkgs/main/osx-arm64::gfortran_impl_osx-arm64-11.2.0-h3f5584c_26 
  gfortran_osx-arm64 pkgs/main/osx-arm64::gfortran_osx-arm64-11.2.0-hf112342_1 
  gmp                pkgs/main/osx-arm64::gmp-6.3.0-h313beb8_0 
  isl                pkgs/main/osx-arm64::isl-0.22.1-hc377ac9_3 
  ld64               pkgs/main/osx-arm64::ld64-711-h3c27c41_3 
  libclang-cpp17     pkgs/main/osx-arm64::libclang-cpp17-17.0.6-default_h000693a_6 
  libcxx             pkgs/main/osx-arm64::libcxx-17.0.6-he5c5206_2 
  libcxx-devel       pkgs/main/osx-arm64::libcxx-devel-17.0.6-hbf97328_2 
  libffi             pkgs/main/osx-arm64::libffi-3.4.4-hca03da5_1 
  libgfortran        pkgs/main/osx-arm64::libgfortran-5.0.0-11_3_0_hca03da5_28 
  libgfortran-devel~ pkgs/main/noarch::libgfortran-devel_osx-arm64-11.2.0-h31830f3_26 
  libgfortran5       pkgs/main/osx-arm64::libgfortran5-11.3.0-h009349e_28 
  libiconv           pkgs/main/osx-arm64::libiconv-1.16-h80987f9_3 
  libllvm17          pkgs/main/osx-arm64::libllvm17-17.0.6-hac7df47_1 
  libzlib            pkgs/main/osx-arm64::libzlib-1.3.1-h5f15de7_0 
  llvm               pkgs/main/osx-arm64::llvm-17.0.6-h8abdc9b_1 
  llvm-openmp        pkgs/main/osx-arm64::llvm-openmp-20.1.8-he822017_0 
  llvm-tools         pkgs/main/osx-arm64::llvm-tools-17.0.6-h7e95266_1 
  lz4-c              pkgs/main/osx-arm64::lz4-c-1.9.4-h313beb8_1 
  mpc                pkgs/main/osx-arm64::mpc-1.3.1-h80987f9_0 
  mpfr               pkgs/main/osx-arm64::mpfr-4.2.1-h80987f9_0 
  tapi               pkgs/main/osx-arm64::tapi-1100.0.11-h8754e6a_1 
  xz                 pkgs/main/osx-arm64::xz-5.6.4-h80987f9_1 
  zlib               pkgs/main/osx-arm64::zlib-1.3.1-h5f15de7_0 
  zstd               pkgs/main/osx-arm64::zstd-1.5.7-h817c040_0 


Proceed ([y]/n)?
```