### PR TITLE
gcc 14.3.0 & clang 20.1.8 && gfortran 14.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,7 @@ outputs:
         - llvm-openmp               # [osx]
     test:
       commands:
+        - $CC --version  # [unix]
         - $CC --help  # [unix]
         # Linux-specific environment variable checks
         - echo "C compiler environment variables:" # [unix]
@@ -74,6 +75,7 @@ outputs:
         - echo "Testing Windows c-compiler"  # [win]
         - if defined CC (echo %CC% exists) ELSE (echo CC not defined & exit /b 1)  # [win]
         - where cl  # [win]
+        - cl  # [win]
 
   - name: cxx-compiler
     about:
@@ -100,6 +102,7 @@ outputs:
         - clangxx_osx-64       # [osx and x86_64]
     test:
       commands:
+        - $CXX --version  # [unix]
         - $CXX --help  # [unix]
         # Linux-specific environment variable checks
         - echo "C++ compiler environment variables:" # [unix]
@@ -111,6 +114,7 @@ outputs:
         - echo "Testing Windows cxx-compiler"  # [win]
         - if defined CXX (echo %CXX% exists) ELSE (echo CXX not defined & exit /b 1)  # [win]
         - where cl  # [win]
+        - cl  # [win]
 
   - name: fortran-compiler
     about:
@@ -142,6 +146,7 @@ outputs:
         - {{ pin_subpackage('c-compiler', exact=True) }}  # [linux]
     test:
       commands:
+        - $FC --version  # [unix]
         - $FC --help  # [unix]
         # Linux-specific environment variable checks
         - echo "Fortran compiler environment variables:" # [unix]
@@ -152,6 +157,7 @@ outputs:
 {%- endfor %}  # [unix]
         - echo "Testing Windows fortran-compiler"  # [win]
         - where ifort || (echo ifort not in PATH & exit /b 1)  # [win]
+        - ifort /help  # [win]
 
   - name: compilers
     about:
@@ -186,6 +192,7 @@ outputs:
         - echo "Testing Windows compilers metapackage"  # [win]
         - if defined CC (echo %CC% exists) ELSE (echo CC not defined & exit /b 1)  # [win]
         - if defined CXX (echo %CXX% exists) ELSE (echo CXX not defined & exit /b 1)  # [win]
+        - if defined FC (echo %FC% exists) ELSE (echo FC not defined & exit /b 1)  # [win]
 
 about:
   home: https://conda-forge.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@
 
 package:
   name: compilers
-  version: 1.9.1
+  version: 1.11.0
 
 build:
    number: 0
@@ -103,7 +103,7 @@ outputs:
         - $CXX --help  # [unix]
         # Linux-specific environment variable checks
         - echo "C++ compiler environment variables:" # [unix]
-        - echo CXX=$CXX # [unix] 
+        - echo CXX=$CXX # [unix]
         - command -v "$CXX" > /dev/null  # [unix]
 {%- for command in commands['cxx-compiler'] %}  # [unix]
         - $PREFIX/bin/${BUILD}-{{ command }} --help  # [unix]


### PR DESCRIPTION
compilers 1.11.0

**Destination channel:** defaults

### Links

- [PKG-10994](https://anaconda.atlassian.net/browse/PKG-10994) 
- [Upstream repository](https://github.com/conda-forge/compilers-feedstock)
- Upstream changelog/diff
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump package version to match with conda-forge
- `gcc` version: 14.3.0
- `clang` version: 20.1.8
- `gfortran` version: 14.3.0
- `msvc` version: 14.29.30133
- `ifort` version: 2022.1.0 (`ifort /help` prints 2021.6.0 Build 20220226_000000)

[PKG-10994]: https://anaconda.atlassian.net/browse/PKG-10994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ