### PR TITLE
Bump version to 1.12.0 for LLVM 21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@
 
 package:
   name: compilers
-  version: 1.11.0
+  version: 1.12.0
 
 build:
    number: 0


### PR DESCRIPTION
compilers 1.12.0           
                                                                                                                                  
  Destination channel: defaults
                                                                                                                                                                                    
  Links
                                                                                                                                                                                    
  - https://anaconda.atlassian.net/browse/PKG-10610                            
  - https://github.com/conda-forge/compilers-feedstock
  - Relevant dependency PRs:
    - https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/33
    - https://github.com/AnacondaRecipes/clangdev-feedstock/pull/21
    - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/24
    - https://github.com/AnacondaRecipes/openmp-feedstock/pull/7

  Explanation of changes:

  - Bump version 1.11.0 → 1.12.0 to pick up LLVM 21 compiler stack (clang 21.1.8 on macOS)
  - This is a metapackage — no code changes, just a version bump to trigger a rebuild with the updated compiler pinnings